### PR TITLE
TypeScript: Explicitly Typing Props/Slots/Events + Generics

### DIFF
--- a/text/ts-typing-props-slots-events.md
+++ b/text/ts-typing-props-slots-events.md
@@ -116,11 +116,33 @@ This works the same as for typing events. You probably won't use that because it
 
 ### Generics
 
-You want to specify some generic connection between props/slots/events. For this you use the `<script>` attribute `generics`. The contents of that attribute have to be valid generic typings.
+You want to specify some generic connection between props/slots/events. For example you have a component which has an input prop `item`, and an event called `itemChanged`. You want to use this component for arbitrary kinds of item, but you want to make sure that the types for `item` and `itemChanged` are the same. Generics come in handy then. You can read more about them on the [official TypeScript page](https://www.typescriptlang.org/docs/handbook/generics.html).
+
+##### Option 1
+You use a new `<script>` attribute called `generics`. The contents of that attribute have to be valid generic typings.
 
 ```html
 <script lang="ts" generics="T extends boolean, X">
     import {createEventDispatcher} from "svelte";
+
+    export let array1: T[];
+    export let item1: T;
+    export let array2: X[];
+
+    const dispatch = createEventDispatcher<{arrayItemClick: X}>();
+</script>
+
+...
+```
+
+##### Option 2
+You use a new reserved interface called `ComponentGenerics` and do the typing on it, not declaring any properties on it.
+
+```html
+<script lang="ts">
+    import {createEventDispatcher} from "svelte";
+    
+    interface ComponentGenerics<T extends boolean, X> {}
 
     export let array1: T[];
     export let item1: T;
@@ -143,6 +165,34 @@ If you want to type all at once, because you like to have the definition in one 
         props: { items: T[]; someOptionalProp?: string; };
         events: { itemClick: CustomEvent<T>; };
         slots: { default: { item: T; }; };
+    }
+</script>
+
+...
+```
+
+### ComponentDef alternative: Namespace
+
+As an alternative to the `ComponentDef` interface, one could use a namespace and put the interfaces inside it. That would make refactoring easier if you for example start of with typing only the events but want to add more typings to slots later on. This would come at the cost of uncanny-valley-stuff for defining the generics.
+
+```html
+<script lang="ts">
+    // ...
+    declare namespace Component {
+      interface Generics<T> {}
+    
+      interface Events {
+        itemClick: CustomEvent<T>; // use generic T here which will be the one defined in Generics
+      }
+    
+      interface Props {
+        itemClick: CustomEvent<T>;
+        someOptionalProp?: string;
+      }
+    
+      interface Slots {
+        default: { item: T }
+      }
     }
 </script>
 

--- a/text/ts-typing-props-slots-events.md
+++ b/text/ts-typing-props-slots-events.md
@@ -154,6 +154,23 @@ You use a new reserved interface called `ComponentGenerics` and do the typing on
 ...
 ```
 
+#### Option 3
+You use new reserved type called `ComponentGeneric`.
+
+```html
+<script lang="ts">
+    import {createEventDispatcher} from "svelte";
+
+    type T = ComponentGeneric<boolean>; // extends boolean
+    type X = ComponentGeneric; // any
+
+    export let array1: T[];
+    export let item1: T;
+    export let array2: X[];
+    const dispatch = createEventDispatcher<{arrayItemClick: X}>();
+</script>
+```
+
 ### ComponentDef
 
 If you want to type all at once, because you like to have the definition in one place or want to better define a generic relationship, you can use the `ComponentDef` interface.

--- a/text/ts-typing-props-slots-events.md
+++ b/text/ts-typing-props-slots-events.md
@@ -128,6 +128,11 @@ You use new reserved type called `ComponentGeneric`.
 
     type T = ComponentGeneric<boolean>; // extends boolean
     type X = ComponentGeneric; // any
+    
+    // you can use generics inside the other interfaces
+    interface ComponentSlots {
+        default: { aSlot: T }
+    }
 
     export let array1: T[];
     export let item1: T;

--- a/text/ts-typing-props-slots-events.md
+++ b/text/ts-typing-props-slots-events.md
@@ -115,6 +115,8 @@ This works the same as for typing events. You probably won't use that because it
 </script>
 ```
 
+If you define `$$Props`, all possible props need to be part of it. If you use `$$props` or `$$restProps` then that does _not_ widen the type, still only those defined in `$$Props` are allowed.
+
 ### Generics
 
 You want to specify some generic connection between props/slots/events. For example you have a component which has an input prop `item`, and an event called `itemChanged`. You want to use this component for arbitrary kinds of item, but you want to make sure that the types for `item` and `itemChanged` are the same. Generics come in handy then. You can read more about them on the [official TypeScript page](https://www.typescriptlang.org/docs/handbook/generics.html).

--- a/text/ts-typing-props-slots-events.md
+++ b/text/ts-typing-props-slots-events.md
@@ -122,6 +122,24 @@ If you define `$$Props`, all possible props need to be part of it. If you use `$
 You want to specify some generic connection between props/slots/events. For example you have a component which has an input prop `item`, and an event called `itemChanged`. You want to use this component for arbitrary kinds of item, but you want to make sure that the types for `item` and `itemChanged` are the same. Generics come in handy then. You can read more about them on the [official TypeScript page](https://www.typescriptlang.org/docs/handbook/generics.html).
 
 #### Solution
+
+You use a new `<script>` attribute called `generics`. The contents of that attribute have to be valid generic typings.
+
+```html
+<script lang="ts" generics="T extends boolean, X">
+    import {createEventDispatcher} from "svelte";
+
+    export let array1: T[];
+    export let item1: T;
+    export let array2: X[];
+
+    const dispatch = createEventDispatcher<{arrayItemClick: X}>();
+</script>
+
+...
+```
+
+##### Discarded alternative 1
 You use new reserved type called `$$Generic`.
 
 ```html
@@ -143,24 +161,7 @@ You use new reserved type called `$$Generic`.
 </script>
 ```
 
-##### Discarded alternative 1
-You use a new `<script>` attribute called `generics`. The contents of that attribute have to be valid generic typings.
-
-```html
-<script lang="ts" generics="T extends boolean, X">
-    import {createEventDispatcher} from "svelte";
-
-    export let array1: T[];
-    export let item1: T;
-    export let array2: X[];
-
-    const dispatch = createEventDispatcher<{arrayItemClick: X}>();
-</script>
-
-...
-```
-
-Discarded because it is invalid TypeScript without additional transformations.
+Discarded because it is invalid TypeScript when using advanced typings such as `const T extends string` and it's harder to read. The `generics` attribute reads exactly like the generics on a function.
 
 ##### Discarded alternative 2
 You use a new reserved interface called `$$Generics` and do the typing on it, not declaring any properties on it.

--- a/text/ts-typing-props-slots-events.md
+++ b/text/ts-typing-props-slots-events.md
@@ -37,7 +37,7 @@ You start with one event which is from your own typed `createEventDispatcher` an
 <button on:click>Forwarded</button>
 ```
 
-Now you want to ensure that listeing to anything else than `on:own`/`on:click` throws a type error. For that you use the new `<script>` attribute `strictEvents`:
+Now you want to ensure that listening to anything else than `on:own`/`on:click` throws a type error. For that you use the new `<script>` attribute `strictEvents`:
 
 ```html
 <script lang="ts" strictEvents>
@@ -134,7 +134,7 @@ You want to specify some generic connection between props/slots/events. For this
 
 ### ComponentDef
 
-If you want to type all at once, because you like to have the definition on one place or want to better define a generic relationship, you can use the `ComponentDef` interface.
+If you want to type all at once, because you like to have the definition in one place or want to better define a generic relationship, you can use the `ComponentDef` interface.
 
 ```html
 <script lang="ts">
@@ -149,11 +149,9 @@ If you want to type all at once, because you like to have the definition on one 
 ...
 ```
 
-You can also leave out props/events/slots in that interface depending on what you actually use in your component.
-
 ### Summary
 
-As you can see, there would be several options to achieve the same. You can use `ComponentDef` to type all at once, or you can mix and match the other possibilities to only type part of it. The drawback is that there is more than one way to achieve the same goal. But only having `ComponentDef` would be too much typing overhead of you only want to specifically type parts of the component. In general, props, slots and their types are already inferable quite nicely at this point. Only generics and events are where you really would need this.
+As you can see, there would be several options to achieve the same. You can use `ComponentDef` to type all at once, or you can mix and match the other possibilities to only type part of it. The drawback is that there is more than one way to achieve the same goal. But only having `ComponentDef` may be too much typing overhead of you only want to specifically type parts of the component. In general, props, slots and their types are already inferable quite nicely at this point. Only generics and events are where you really would need this.
 
 ### Implementation hurdles
 

--- a/text/ts-typing-props-slots-events.md
+++ b/text/ts-typing-props-slots-events.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Provide possibilites for TypeScript users to strongly type a Svelte component's props/events/slots, including generics. For that, we introduce reserved interfaces named `ComponentProps`, `ComponentEvents`, `ComponentSlots`. We also introduce a concept for generics and a `<script>` attribute for marking a component as having no other events besides the ones defined within.
+Provide possibilites for TypeScript users to strongly type a Svelte component's props/events/slots, including generics. For that, we introduce reserved interfaces named `$$Props`, `$$Events`, `$$Slots`. We also introduce a concept for generics and a `<script>` attribute for marking a component as having no other events besides the ones defined within.
 
 While this is not a change to Svelte's core, it's still something that needs to be specified so intellisense implementers have something to adhere to.
 
@@ -66,14 +66,14 @@ Now you add one event which comes from a dispatcher mixin:
 <button on:click>Forwarded</button>
 ```
 
-In this case `strictEvents` will not work anymore because we cannot know that `mixinDispatch` dispatches events. So now you use the `ComponentEvents` interface.
+In this case `strictEvents` will not work anymore because we cannot know that `mixinDispatch` dispatches events. So now you use the `$$Events` interface.
 
 ```html
 <script lang="ts">
     import {mixinDispatch} from "somewhere";
     import {createEventDispatcher} from "svelte";
 
-    interface ComponentEvents {
+    interface $$Events {
         mixinEvent: CustomEvent<string>;
         own: CustomEvent<boolean>;
         click: MouseEvent;
@@ -93,7 +93,7 @@ This works the same as for typing events.
 
 ```html
 <script lang="ts">
-    interface ComponentSlots {
+    interface $$Slots {
         default: { prop: boolean; };
     }
 </script>
@@ -107,7 +107,7 @@ This works the same as for typing events. You probably won't use that because it
 
 ```html
 <script lang="ts">
-    interface ComponentProps {
+    interface $$Props {
         prop: boolean;
     }
 
@@ -120,17 +120,17 @@ This works the same as for typing events. You probably won't use that because it
 You want to specify some generic connection between props/slots/events. For example you have a component which has an input prop `item`, and an event called `itemChanged`. You want to use this component for arbitrary kinds of item, but you want to make sure that the types for `item` and `itemChanged` are the same. Generics come in handy then. You can read more about them on the [official TypeScript page](https://www.typescriptlang.org/docs/handbook/generics.html).
 
 #### Solution
-You use new reserved type called `ComponentGeneric`.
+You use new reserved type called `$$Generic`.
 
 ```html
 <script lang="ts">
     import {createEventDispatcher} from "svelte";
 
-    type T = ComponentGeneric<boolean>; // extends boolean
-    type X = ComponentGeneric; // any
+    type T = $$Generic<boolean>; // extends boolean
+    type X = $$Generic; // any
     
     // you can use generics inside the other interfaces
-    interface ComponentSlots {
+    interface $$Slots {
         default: { aSlot: T }
     }
 
@@ -161,13 +161,13 @@ You use a new `<script>` attribute called `generics`. The contents of that attri
 Discarded because it is invalid TypeScript without additional transformations.
 
 ##### Discarded alternative 2
-You use a new reserved interface called `ComponentGenerics` and do the typing on it, not declaring any properties on it.
+You use a new reserved interface called `$$Generics` and do the typing on it, not declaring any properties on it.
 
 ```html
 <script lang="ts">
     import {createEventDispatcher} from "svelte";
     
-    interface ComponentGenerics<T extends boolean, X> {}
+    interface $$Generics<T extends boolean, X> {}
 
     export let array1: T[];
     export let item1: T;
@@ -237,7 +237,7 @@ As you can see, there would be several options to achieve the same. You can use 
 
 ### Implementation hurdles
 
-We would need to make sure that we can provide some meaningful errors if the definition and the actual types don't match. So if someone types `ComponentSlots` as `{foo: boolean;}` but does `<slot foo={'aString'}></slot>`, we must highlight that. I have not looked closely into how this can be achieved yet because I want to first have agreement on the API.
+We would need to make sure that we can provide some meaningful errors if the definition and the actual types don't match. So if someone types `$$Slots` as `{foo: boolean;}` but does `<slot foo={'aString'}></slot>`, we must highlight that. I have not looked closely into how this can be achieved yet because I want to first have agreement on the API.
 
 ## How we teach this
 
@@ -254,7 +254,7 @@ For users: Enhance docs. For intellisense devs: A more formal specification outl
 
 - Don't do anything and say "well, there are some limits". VueJS for example also cannot deal with generics as far as I know.
 - Only provide parts of this solution: `strictEvents` and generics, and from the interfaces only `ComponentDef`, and tell people "if you want to type it, type it all".
-- Shorter interface name alternatives: `Props` / `Events` / `Slots` / `Generic`. More likely that they clash with existing definitions?
+- Interface name alternatives: `Props` / `Events` / `Slots` / `Generic`. More likely that they clash with existing definitions. `ComponentProps` / ... - too verbose.
 
 ## Unresolved questions
 


### PR DESCRIPTION
[rendered](https://github.com/dummdidumm/rfcs/blob/ts-typedefs-within-svelte-components/text/ts-typing-props-slots-events.md)